### PR TITLE
usFeat/azure attached file fallback

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -102,7 +102,8 @@ _SUPPORTED_FILE_CONTENT_MIME_TYPES = frozenset({
 })
 
 # Providers that require file_id instead of inline file_data
-_FILE_ID_REQUIRED_PROVIDERS = frozenset({"openai", "azure"})
+_FILE_ID_REQUIRED_PROVIDERS = frozenset({"openai"})
+_FILE_ATTACHED_DISABLE_PROVIDERS = frozenset({"azure"})
 
 _MISSING_TOOL_RESULT_MESSAGE = (
     "Error: Missing tool result (tool execution may have been interrupted "
@@ -225,6 +226,8 @@ def _requires_file_uri_fallback(
   """Returns True when `file_uri` should not be sent as a file content block."""
   if provider in _FILE_ID_REQUIRED_PROVIDERS:
     return not _looks_like_openai_file_id(file_uri)
+  if provider in _FILE_ATTACHED_DISABLE_PROVIDERS:
+    return True
   if provider == "anthropic":
     return True
   if provider == "vertex_ai" and not _is_litellm_gemini_model(model):
@@ -756,16 +759,39 @@ async def _get_content(
               "type": "file",
               "file": {"file_id": file_response.id},
           })
-        else:
+        elif provider not in _FILE_ATTACHED_DISABLE_PROVIDERS:
           content_objects.append({
               "type": "file",
               "file": {"file_data": data_uri},
           })
+        else:
+          logger.debug(
+              "File URI %s not supported for provider %s, using text fallback",
+              _redact_file_uri_for_log(
+                  "inline_data",
+                  display_name=part.inline_data.display_name,
+              ),
+              provider,
+          )
+          identifier = part.inline_data.display_name
+          content_objects.append({
+              "type": "text",
+              "text": f'[File reference: "{identifier}"]',
+          })
       else:
-        raise ValueError(
-            "LiteLlm(BaseLlm) does not support content part with MIME type "
-            f"{part.inline_data.mime_type}."
+        logger.debug(
+            "File URI %s not supported for provider %s, using text fallback",
+            _redact_file_uri_for_log(
+                "inline_data",
+                display_name=part.inline_data.display_name,
+            ),
+            provider,
         )
+        identifier = part.inline_data.display_name
+        content_objects.append({
+            "type": "text",
+            "text": f'[File reference: "{identifier}"]',
+        })
     elif part.file_data and part.file_data.file_uri:
       if (
           provider in _FILE_ID_REQUIRED_PROVIDERS


### PR DESCRIPTION
attached file fallback
When azure provider

```

  File "/app/.venv/lib/python3.10/site-packages/google/adk/runners.py", line 562, in run_async
    async for event in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/runners.py", line 550, in _run_with_trace
    async for event in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/runners.py", line 779, in _exec_with_plugin
    async for event in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/runners.py", line 539, in execute
    async for event in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/agents/base_agent.py", line 294, in run_async
    async for event in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/agents/llm_agent.py", line 468, in _run_async_impl
    async for event in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 365, in run_async
    async for event in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 442, in _run_one_step_async
    async for llm_response in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 829, in _call_llm_async
    async for event in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 813, in _call_llm_with_tracing
    async for llm_response in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 1061, in _run_and_handle_error
    raise model_error
  File "/app/.venv/lib/python3.10/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 1047, in _run_and_handle_error
    async for response in agen:
  File "/app/.venv/lib/python3.10/site-packages/google/adk/models/lite_llm.py", line 1776, in generate_content_async
    async for part in await self.llm_client.acompletion(**completion_args):
  File "/app/.venv/lib/python3.10/site-packages/google/adk/models/lite_llm.py", line 348, in acompletion
    return await acompletion(
  File "/app/.venv/lib/python3.10/site-packages/litellm/utils.py", line 1516, in wrapper_async
    raise e
  File "/app/.venv/lib/python3.10/site-packages/litellm/utils.py", line 1374, in wrapper_async
    result = await original_function(*args, **kwargs)
  File "/app/.venv/lib/python3.10/site-packages/litellm/main.py", line 544, in acompletion
    raise exception_type(
  File "/app/.venv/lib/python3.10/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 2284, in exception_type
    raise e
  File "/app/.venv/lib/python3.10/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 2027, in exception_type
    raise BadRequestError(
litellm.exceptions.BadRequestError: litellm.BadRequestError: AzureException BadRequestError - Invalid Value: 'file'. This model does not support file content types.
```