### PR TITLE
feat: stream intermediate results from generator tools in non-live runs

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -20,6 +20,7 @@ import asyncio
 import base64
 import binascii
 from concurrent.futures import ThreadPoolExecutor
+import contextlib
 import contextvars
 import copy
 import inspect
@@ -27,6 +28,7 @@ import json
 import logging
 import threading
 from typing import Any
+from typing import AsyncGenerator
 from typing import Callable
 from typing import cast
 from typing import Dict
@@ -637,6 +639,15 @@ async def _execute_single_function_call_async(
         function_response = await __call_tool_async(
             tool, args=function_args, tool_context=tool_context
         )
+        # Inside the try: a tool that reports progress runs the rest of its
+        # body while it is drained, so a failure after its first yield has to
+        # reach the error callbacks like any other tool failure.
+        function_response = await _drain_tool_result_stream(
+            function_response,
+            tool=tool,
+            tool_context=tool_context,
+            invocation_context=invocation_context,
+        )
       except Exception as tool_error:
         error_response = await _run_on_tool_error_callbacks(
             tool=tool,
@@ -1111,6 +1122,180 @@ async def _emit_streaming_tool_event(
           ),
       )
   )
+
+
+async def _iter_tool_yields(
+    generator: object,
+) -> AsyncGenerator[object, None]:
+  """Yields every value a generator tool produces, async or sync.
+
+  Args:
+    generator: The async or sync generator the tool returned.
+
+  Yields:
+    Each value the tool yields, in order.
+  """
+  if inspect.isasyncgen(generator):
+    async with Aclosing(generator) as agen:
+      async for value in agen:
+        yield value
+    return
+  # A sync generator is stepped on the event loop, like the body of any other
+  # synchronous tool. Offloading it to a thread would move user code off the
+  # loop only because the tool yields, which is not a difference the tool
+  # asked for. Delivery is still incremental: enqueuing each intermediate
+  # result awaits, so the runner drains between yields.
+  with contextlib.closing(cast(Any, generator)) as gen:
+    for value in gen:
+      yield value
+
+
+async def _emit_intermediate_tool_result(
+    function_result: object,
+    *,
+    tool: BaseTool,
+    tool_context: ToolContext,
+    invocation_context: InvocationContext,
+) -> None:
+  """Streams one intermediate result of a generator tool to the client.
+
+  Args:
+    function_result: The value the tool yielded.
+    tool: The tool that yielded it.
+    tool_context: The context of the call, for its function call id.
+    invocation_context: The invocation to enqueue on.
+  """
+  # Mirrors __build_response_event: media has to come out before the result is
+  # coerced to a dict, so a media part yielded on its own is still reachable.
+  remaining_result, function_response_parts = _extract_multimodal_parts(
+      function_result
+  )
+  content = _build_function_response_content(
+      tool,
+      _normalize_tool_result(remaining_result),
+      tool_context.function_call_id,
+      function_response_parts,
+  )
+  for part in content.parts or []:
+    if part.function_response is not None:
+      # Marks this as one of several responses to the call, so a client can
+      # tell progress from the answer without interpreting the payload.
+      part.function_response.will_continue = True
+
+  await invocation_context._enqueue_event(
+      Event(
+          content=content,
+          author=_require_agent_name(invocation_context),
+          invocation_id=invocation_context.invocation_id,
+          # The same branch the final response carries: an intermediate result
+          # answers the same call, so whatever groups one groups the other.
+          branch=invocation_context.branch,
+          # Keeps the result out of the session, and so out of the history the
+          # model is given on later turns: an intermediate result is for the
+          # client only. It also keeps the tool from blocking until the client
+          # has consumed it.
+          partial=True,
+          # Deliberately not tool_context.actions, which the call is still
+          # accumulating: sharing it would attach state the tool has not
+          # finished producing to an event that is never applied.
+          actions=EventActions(),
+      )
+  )
+
+
+async def _drain_tool_result_stream(
+    function_response: object,
+    *,
+    tool: BaseTool,
+    tool_context: ToolContext,
+    invocation_context: InvocationContext,
+) -> object:
+  """Streams a generator tool's progress and returns the result for the model.
+
+  A tool that yields instead of returning reports progress. Every value it
+  yields but the last is streamed to the client as a partial event and is
+  never shown to the model; the last one is the tool result, and is the only
+  one the model sees. A yielded ``Event`` is a user-facing message rather than
+  a result, so it is streamed and then does not compete to be the last value.
+
+  Args:
+    function_response: The tool's return value. Anything that is not a
+      generator is returned unchanged.
+    tool: The tool being called.
+    tool_context: The context of the call.
+    invocation_context: The invocation to stream on.
+
+  Returns:
+    The last non-Event value the tool yielded, or None if it yielded none.
+  """
+  if not inspect.isasyncgen(function_response) and not inspect.isgenerator(
+      function_response
+  ):
+    return function_response
+
+  # Checked up front rather than per yield: a flow driven outside Runner has
+  # nowhere to deliver progress, and the tool should still run to completion
+  # and report its result instead of failing because it reports progress.
+  can_stream = invocation_context._event_queue is not None
+  if not can_stream:
+    logger.warning(
+        'Tool `%s` yields intermediate results, but this invocation has no'
+        ' event queue to deliver them on, so only its last result is'
+        ' reported. Streaming intermediate results requires running the agent'
+        ' through Runner.',
+        tool.name,
+    )
+
+  result: object = None
+  has_result = False
+  try:
+    async with Aclosing(_iter_tool_yields(function_response)) as stream:
+      async for value in stream:
+        if isinstance(value, Event):
+          if can_stream:
+            await _emit_streaming_tool_event(
+                value,
+                tool=tool,
+                tool_context=tool_context,
+                invocation_context=invocation_context,
+            )
+          continue
+        if has_result and can_stream:
+          # Emitted one value behind: the last value a tool yields is its
+          # result, and which value that is is only known once the next one
+          # arrives.
+          await _emit_intermediate_tool_result(
+              result,
+              tool=tool,
+              tool_context=tool_context,
+              invocation_context=invocation_context,
+          )
+        result = value
+        has_result = True
+  except Exception:
+    # The last value was held back in case it turned out to be the result. The
+    # tool failed instead, so there is no result and everything it yielded was
+    # progress. Reporting that last value is what a client that has been
+    # showing progress needs; dropping it would strand the client on the
+    # second-to-last update. Only `Exception` is caught, so a cancelled
+    # invocation does not enqueue anything on its way out.
+    if has_result and can_stream:
+      try:
+        await _emit_intermediate_tool_result(
+            result,
+            tool=tool,
+            tool_context=tool_context,
+            invocation_context=invocation_context,
+        )
+      except Exception:  # pylint: disable=broad-except
+        # Never masks the tool's own failure, which is what the caller has to
+        # see, with a failure to report progress about it.
+        logger.exception(
+            'Failed to report the last progress of failing tool `%s`.',
+            tool.name,
+        )
+    raise
+  return result
 
 
 async def _process_function_live_helper(

--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -639,9 +639,6 @@ async def _execute_single_function_call_async(
         function_response = await __call_tool_async(
             tool, args=function_args, tool_context=tool_context
         )
-        # Inside the try: a tool that reports progress runs the rest of its
-        # body while it is drained, so a failure after its first yield has to
-        # reach the error callbacks like any other tool failure.
         function_response = await _drain_tool_result_stream(
             function_response,
             tool=tool,
@@ -1140,11 +1137,7 @@ async def _iter_tool_yields(
       async for value in agen:
         yield value
     return
-  # A sync generator is stepped on the event loop, like the body of any other
-  # synchronous tool. Offloading it to a thread would move user code off the
-  # loop only because the tool yields, which is not a difference the tool
-  # asked for. Delivery is still incremental: enqueuing each intermediate
-  # result awaits, so the runner drains between yields.
+
   with contextlib.closing(cast(Any, generator)) as gen:
     for value in gen:
       yield value
@@ -1165,8 +1158,6 @@ async def _emit_intermediate_tool_result(
     tool_context: The context of the call, for its function call id.
     invocation_context: The invocation to enqueue on.
   """
-  # Mirrors __build_response_event: media has to come out before the result is
-  # coerced to a dict, so a media part yielded on its own is still reachable.
   remaining_result, function_response_parts = _extract_multimodal_parts(
       function_result
   )
@@ -1178,8 +1169,6 @@ async def _emit_intermediate_tool_result(
   )
   for part in content.parts or []:
     if part.function_response is not None:
-      # Marks this as one of several responses to the call, so a client can
-      # tell progress from the answer without interpreting the payload.
       part.function_response.will_continue = True
 
   await invocation_context._enqueue_event(
@@ -1187,17 +1176,8 @@ async def _emit_intermediate_tool_result(
           content=content,
           author=_require_agent_name(invocation_context),
           invocation_id=invocation_context.invocation_id,
-          # The same branch the final response carries: an intermediate result
-          # answers the same call, so whatever groups one groups the other.
           branch=invocation_context.branch,
-          # Keeps the result out of the session, and so out of the history the
-          # model is given on later turns: an intermediate result is for the
-          # client only. It also keeps the tool from blocking until the client
-          # has consumed it.
           partial=True,
-          # Deliberately not tool_context.actions, which the call is still
-          # accumulating: sharing it would attach state the tool has not
-          # finished producing to an event that is never applied.
           actions=EventActions(),
       )
   )
@@ -1233,9 +1213,6 @@ async def _drain_tool_result_stream(
   ):
     return function_response
 
-  # Checked up front rather than per yield: a flow driven outside Runner has
-  # nowhere to deliver progress, and the tool should still run to completion
-  # and report its result instead of failing because it reports progress.
   can_stream = invocation_context._event_queue is not None
   if not can_stream:
     logger.warning(
@@ -1261,9 +1238,6 @@ async def _drain_tool_result_stream(
             )
           continue
         if has_result and can_stream:
-          # Emitted one value behind: the last value a tool yields is its
-          # result, and which value that is is only known once the next one
-          # arrives.
           await _emit_intermediate_tool_result(
               result,
               tool=tool,
@@ -1272,13 +1246,8 @@ async def _drain_tool_result_stream(
           )
         result = value
         has_result = True
+
   except Exception:
-    # The last value was held back in case it turned out to be the result. The
-    # tool failed instead, so there is no result and everything it yielded was
-    # progress. Reporting that last value is what a client that has been
-    # showing progress needs; dropping it would strand the client on the
-    # second-to-last update. Only `Exception` is caught, so a cancelled
-    # invocation does not enqueue anything on its way out.
     if has_result and can_stream:
       try:
         await _emit_intermediate_tool_result(

--- a/tests/unittests/flows/llm_flows/test_functions_streaming_results.py
+++ b/tests/unittests/flows/llm_flows/test_functions_streaming_results.py
@@ -1,0 +1,424 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tools that yield intermediate results in non-live runs."""
+
+import asyncio
+import json
+from typing import Any
+from typing import AsyncGenerator
+from typing import Generator
+
+from google.adk.agents.llm_agent import Agent
+from google.adk.events.event import Event
+from google.adk.tools.tool_context import ToolContext
+from google.genai import types
+import pytest
+
+from ... import testing_utils
+
+
+def _function_responses(event: Event) -> list[types.FunctionResponse]:
+  """Returns the function responses an event carries."""
+  if not event.content or not event.content.parts:
+    return []
+  return [
+      part.function_response
+      for part in event.content.parts
+      if part.function_response is not None
+  ]
+
+
+def _tool_progress(events: list[Event]) -> list[tuple[bool, Any]]:
+  """Summarizes every function response as (is intermediate, payload)."""
+  return [
+      (bool(event.partial), function_response.response)
+      for event in events
+      for function_response in _function_responses(event)
+  ]
+
+
+@pytest.mark.asyncio
+async def test_async_generator_tool_streams_every_yield_but_the_last():
+  function_call = types.Part.from_function_call(
+      name='search', args={'q': 'adk'}
+  )
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search(q: str) -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress', 'message': f'searching {q}'}
+    yield {'status': 'inProgress', 'message': 'reading pages'}
+    yield {'status': 'ok', 'result': ['page1', 'page2']}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [
+      (True, {'status': 'inProgress', 'message': 'searching adk'}),
+      (True, {'status': 'inProgress', 'message': 'reading pages'}),
+      (False, {'status': 'ok', 'result': ['page1', 'page2']}),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_only_intermediate_results_are_marked_will_continue():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  will_continue = [
+      function_response.will_continue
+      for event in events
+      for function_response in _function_responses(event)
+  ]
+  assert will_continue == [True, None]
+
+
+@pytest.mark.asyncio
+async def test_intermediate_results_reach_an_sse_client_as_will_continue():
+  """Pins the shape a client reads off the wire, not just the Event in memory."""
+  function_call = types.Part.from_function_call(name='search', args={})
+  function_call.function_call.id = 'call-1'
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  intermediate = next(event for event in events if event.partial)
+  # The same serialization the SSE endpoint applies.
+  payload = json.loads(
+      intermediate.model_dump_json(exclude_none=True, by_alias=True)
+  )
+  assert payload['partial'] is True
+  assert payload['content']['parts'][0]['functionResponse'] == {
+      'willContinue': True,
+      'id': 'call-1',
+      'name': 'search',
+      'response': {'status': 'inProgress'},
+  }
+
+
+@pytest.mark.asyncio
+async def test_intermediate_results_carry_the_call_id_and_tool_name():
+  function_call = types.Part.from_function_call(name='search', args={})
+  function_call.function_call.id = 'call-1'
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  addressing = [
+      (function_response.id, function_response.name)
+      for event in events
+      for function_response in _function_responses(event)
+  ]
+  assert addressing == [('call-1', 'search'), ('call-1', 'search')]
+
+
+@pytest.mark.asyncio
+async def test_intermediate_results_are_not_appended_to_the_session():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  await runner.run_async('test')
+
+  assert _tool_progress(runner.session.events) == [(False, {'status': 'ok'})]
+
+
+@pytest.mark.asyncio
+async def test_intermediate_results_are_not_sent_to_the_model():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  await runner.run_async('test')
+
+  assert testing_utils.simplify_contents(mock_model.requests[1].contents) == [
+      ('user', 'test'),
+      ('model', types.Part.from_function_call(name='search', args={})),
+      (
+          'user',
+          types.Part.from_function_response(
+              name='search', response={'status': 'ok'}
+          ),
+      ),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_sync_generator_tool_streams_every_yield_but_the_last():
+  function_call = types.Part.from_function_call(name='count', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  def count() -> Generator[dict[str, Any], None, None]:
+    yield {'status': 'inProgress', 'done': 1}
+    yield {'status': 'inProgress', 'done': 2}
+    yield {'status': 'ok', 'done': 3}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[count])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [
+      (True, {'status': 'inProgress', 'done': 1}),
+      (True, {'status': 'inProgress', 'done': 2}),
+      (False, {'status': 'ok', 'done': 3}),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_non_dict_yields_are_wrapped_like_a_returned_value():
+  function_call = types.Part.from_function_call(name='count', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def count() -> AsyncGenerator[int, None]:
+    yield 1
+    yield 2
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[count])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [
+      (True, {'result': 1}),
+      (False, {'result': 2}),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_tool_yielding_once_reports_no_intermediate_result():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [(False, {'status': 'ok'})]
+
+
+@pytest.mark.asyncio
+async def test_tool_yielding_nothing_reports_a_null_result():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    if False:
+      yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [(False, {'result': None})]
+
+
+@pytest.mark.asyncio
+async def test_yielded_event_is_delivered_as_a_user_message():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[Any, None]:
+    yield Event(message='looking it up')
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  # The Event is a message for the user, so it is not a function response and
+  # does not displace the result the model sees.
+  assert _tool_progress(events) == [(False, {'status': 'ok'})]
+  messages = [
+      event
+      for event in events
+      if event.content and event.content.parts and event.content.parts[0].text
+  ]
+  assert [
+      (event.content.role, event.content.parts[0].text) for event in messages
+  ] == [('user', 'looking it up'), ('model', 'done')]
+  assert messages[0].branch.startswith('search@')
+
+
+@pytest.mark.asyncio
+async def test_failure_after_the_first_yield_reaches_on_tool_error():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+  errors = []
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    raise ValueError('no results')
+
+  def on_tool_error(*, tool, args, tool_context, error):
+    errors.append(error)
+    return {'status': 'error', 'message': str(error)}
+
+  agent = Agent(
+      name='root_agent',
+      model=mock_model,
+      tools=[search],
+      on_tool_error_callback=on_tool_error,
+  )
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert [str(error) for error in errors] == ['no results']
+  assert _tool_progress(events) == [
+      (True, {'status': 'inProgress'}),
+      (False, {'status': 'error', 'message': 'no results'}),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_unhandled_failure_after_the_first_yield_propagates():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    raise ValueError('no results')
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  with pytest.raises(ValueError, match='no results'):
+    await runner.run_async('test')
+
+
+@pytest.mark.asyncio
+async def test_parallel_generator_tools_stream_independently():
+  function_calls = [
+      types.Part.from_function_call(name='fast', args={}),
+      types.Part.from_function_call(name='slow', args={}),
+  ]
+  mock_model = testing_utils.MockModel.create(
+      responses=[function_calls, 'done']
+  )
+
+  async def fast() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'tool': 'fast', 'status': 'inProgress'}
+    yield {'tool': 'fast', 'status': 'ok'}
+
+  async def slow() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'tool': 'slow', 'status': 'inProgress'}
+    # Yields the event loop so that `fast` finishes first, proving the two
+    # calls are drained concurrently rather than one after the other.
+    await asyncio.sleep(0.05)
+    yield {'tool': 'slow', 'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[fast, slow])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  intermediate = [
+      payload for partial, payload in _tool_progress(events) if partial
+  ]
+  final = [
+      payload for partial, payload in _tool_progress(events) if not partial
+  ]
+  assert sorted(payload['tool'] for payload in intermediate) == ['fast', 'slow']
+  # Both calls answer in one merged non-partial event, as parallel calls always
+  # have.
+  assert len(final) == 2
+  assert all(payload['status'] == 'ok' for payload in final)
+
+
+@pytest.mark.asyncio
+async def test_tool_context_is_still_injected_into_a_generator_tool():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+  seen = []
+
+  async def search(
+      tool_context: ToolContext | None = None,
+  ) -> AsyncGenerator[dict[str, Any], None]:
+    seen.append(tool_context.function_call_id)
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  await runner.run_async('test')
+
+  assert len(seen) == 1 and seen[0]
+
+
+@pytest.mark.asyncio
+async def test_state_a_generator_tool_sets_is_applied_once_at_the_end():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search(
+      tool_context: ToolContext | None = None,
+  ) -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    tool_context.state['hits'] = 2
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  # An intermediate event is never applied, so it must not carry the delta.
+  assert [event.actions.state_delta for event in events if event.partial] == [
+      {}
+  ]
+  assert runner.session.state['hits'] == 2
+
+
+@pytest.mark.asyncio
+async def test_returning_a_plain_value_is_unchanged():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> dict[str, Any]:
+    return {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [(False, {'status': 'ok'})]


### PR DESCRIPTION
## Summary

Reimplements the intermediate-result yielding of #17 on ADK 2.7.1.

A tool that `yield`s instead of `return`ing now reports progress to the client in **non-live** runs. Every value it yields but the last is enqueued as a `partial` event carrying a `FunctionResponse` with `willContinue=true`; the last value is the tool result and is the only one the model sees. A yielded `Event` stays a user-facing message, as it already is in live runs.

Base branch `custom-ver2.7.1` is an unmodified copy of `google/adk-python@e753651b` (ADK 2.7.1), so this PR's diff is exactly the custom change.

## Why this is 1 file instead of #17's 8

Upstream has since absorbed most of the plumbing #17 had to add:

| #17 touched | Now | Why |
|---|---|---|
| `flows/llm_flows/functions.py` | **modified** | the only change |
| `tools/_function_parameter_parse_util.py` | dropped | `_automatic_function_calling_util.py` already unwraps `AsyncGenerator`/`Generator` return annotations to the yield type for the response schema |
| `tools/function_tool.py` | dropped | `_invoke_callable` already returns the generator object |
| `flows/llm_flows/base_llm_flow.py` | dropped | no generator-ization of the flow needed |
| `flows/llm_flows/auth_preprocessor.py` | dropped | `handle_function_calls_async` signature unchanged |
| `tools/_gemini_schema_util.py` / `request_confirmation.py` | dropped | same |
| `tools/crewai_tool.py` | dropped | `_invoke_callable` signature unchanged |

`_concat_function_call_generators` (~40 lines of queue multiplexing) is also gone: `asyncio.gather` already runs parallel calls concurrently and each one enqueues independently.

## Design

Progress is delivered through `InvocationContext._enqueue_event`, the out-of-band channel the runner already drains concurrently with the agent (`Runner._consume_event_queue`). Three new helpers in `functions.py`:

- `_iter_tool_yields` — iterates async and sync generators uniformly. Sync generators are stepped on the event loop, like the body of any other synchronous tool; offloading them to a thread would move user code off the loop only because the tool yields.
- `_emit_intermediate_tool_result` — builds the intermediate event: reuses `_build_function_response_content` (so media parts in a yielded value are still extracted), sets `will_continue=True`, `partial=True`, and a **fresh** `EventActions()` rather than sharing `tool_context.actions`, which the call is still accumulating.
- `_drain_tool_result_stream` — buffers one value behind, because which value is the result is only known once the next one arrives.

The call site is a single insertion in `_execute_single_function_call_async`, right after `__call_tool_async` and **inside the existing `try:`**, so a failure after the first yield reaches `on_tool_error_callback` like any other tool failure.

### Detection is on the returned object, not the function

`inspect.isasyncgen(result)` rather than #17's `inspect.isasyncgenfunction(target)`. A decorated tool therefore streams regardless of how its decorator is written — async-gen wrapper, plain sync wrapper returning the agen, or coroutine returning the agen all work. #17 needed a 3-way `isasyncgenfunction` / `inspect.unwrap` / `__call__` check and still missed the coroutine case.

### `partial=True` fixes a latent bug in #17

#17's intermediate events left `partial` unset, so the runner appended them to the session and fed them back to the model as history on later turns — every `{"status": "inProgress", "message": "..."}` cost tokens on every subsequent request. Marking them `partial` keeps them out of the session and out of the model's history, and keeps the tool from blocking until the client has consumed them.

### Failure after a yield flushes the buffered value

Because of the one-behind buffer, a tool that yields once and then raises would have had its only progress value discarded. If the generator raises, the buffered value is emitted as progress before the error propagates: no result means everything the tool yielded was progress. Only `Exception` is caught, so a cancelled invocation does not enqueue anything on its way out.

## Wire format

What an SSE client receives for an intermediate result:

```json
{"partial": true, "content": {"parts": [{"functionResponse": {
  "willContinue": true, "id": "call-1", "name": "search",
  "response": {"status": "inProgress"}}}]}}
```

Clients that discriminate on their own payload field (e.g. a `status` key) need no change. Clients that skip events with `partial: true` to deduplicate streamed text **will drop progress events** and need to special-case function responses.

## Scope

Non-live only. The live path (`handle_function_calls_live` → `_process_function_live_helper`) is untouched and keeps its existing `live_request_queue.send_content(..., partial=True)` behavior.

Not included, unlike #17: the `base_toolset.py` pydantic serialization change, which was unrelated and rode along.

## Tests

`tests/unittests/flows/llm_flows/test_functions_streaming_results.py`, 17 cases:

- async and sync generator tools stream every yield but the last
- `will_continue` set on intermediates only
- the SSE wire format above, via the endpoint's own `model_dump_json(exclude_none=True, by_alias=True)`
- intermediates addressed with the right call id and tool name
- intermediates **not** appended to the session and **not** present in the next model request
- non-dict yields wrapped like a returned value; single yield; zero yields
- `Event(message=...)` delivered as a user message on a `<tool>@<call_id>` branch, without displacing the result
- failure after the first yield reaches `on_tool_error_callback`, and propagates when unhandled
- parallel generator tools stream independently and still merge into one final event
- `tool_context` still injected; state a generator tool sets applied once at the end, absent from intermediates
- returning a plain value unchanged

### Results

- New tests: **17 passed**
- Full `tests/unittests`: **12,745 passed**, 3 failed — `artifacts/test_artifact_service.py::test_metadata_and_payload_share_permissions` and `test_import_loading.py::test_entry_point_loads_only_allowlisted_packages[agent|runner]` (eager `httpx2` import). All 3 reproduce on `custom-ver2.7.1` with no changes applied, so they are pre-existing and unrelated.
- `isort` 8.0.1 and `pyink` 25.12.0 clean, per `.pre-commit-config.yaml`.

Not verified here: a real end-to-end run against a live model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
