### PR TITLE
fix(litellm): fall back to a text reference for files Azure cannot accept

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -513,6 +513,27 @@ def _file_reference_text(identifier: str) -> str:
   return f'[File reference: "{identifier}"]'
 
 
+def _inline_file_reference_object(
+    inline_data: types.Blob,
+    mime_type: str,
+    *,
+    provider: str,
+    reason: str,
+) -> _TextContentObject:
+  """Returns the text block that replaces an unsendable inline file."""
+  # Falls back to the MIME type because inline data often arrives without a
+  # display name, and `[File reference: "None"]` tells the model less than the
+  # kind of file that was attached.
+  identifier = inline_data.display_name or mime_type
+  logger.debug(
+      "Inline file %s %s %s, using text fallback.",
+      identifier,
+      reason,
+      provider or "(unknown provider)",
+  )
+  return _TextContentObject(type="text", text=_file_reference_text(identifier))
+
+
 def _is_file_uri_supported(provider: str, model: str, file_uri: str) -> bool:
   """Returns True when `file_uri` can be sent as a file content block."""
   # If the model is proxied, the proxy might accept arbitrary URIs.
@@ -1602,23 +1623,12 @@ async def _get_content(
       elif not _supports_file_content_blocks(provider, model):
         # Checked before the upload below: uploading first would spend a request
         # and leave a file behind that no message can then refer to.
-        logger.debug(
-            "Inline file %s cannot be sent as a file content block to provider"
-            " %s, using text fallback.",
-            _redact_file_uri_for_log(
-                "inline_data", display_name=part.inline_data.display_name
-            ),
-            provider,
-        )
         content_objects.append(
-            _TextContentObject(
-                type="text",
-                # Falls back to the MIME type because inline data often arrives
-                # without a display name, and `[File reference: "None"]` tells
-                # the model less than the kind of file that was attached.
-                text=_file_reference_text(
-                    part.inline_data.display_name or mime_type
-                ),
+            _inline_file_reference_object(
+                part.inline_data,
+                mime_type,
+                provider=provider,
+                reason="cannot be sent as a file content block to provider",
             )
         )
       elif mime_type in _SUPPORTED_FILE_CONTENT_MIME_TYPES:
@@ -1651,9 +1661,17 @@ async def _get_content(
               _FileContentObject(type="file", file={"file_data": data_uri})
           )
       else:
-        raise ValueError(
-            "LiteLlm(BaseLlm) does not support content part with MIME type "
-            f"{part.inline_data.mime_type}."
+        # A type no provider takes as a file block is still worth naming rather
+        # than failing the turn over. The attachment is one part of a request
+        # the rest of which is answerable, and the model can report what it was
+        # not given.
+        content_objects.append(
+            _inline_file_reference_object(
+                part.inline_data,
+                mime_type,
+                provider=provider,
+                reason="is not a MIME type that can be sent as a file to",
+            )
         )
     elif part.file_data and part.file_data.file_uri:
       if (

--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -242,6 +242,13 @@ _SUPPORTED_FILE_CONTENT_MIME_TYPES = frozenset({
 # Providers that require file_id instead of inline file_data
 _FILE_ID_REQUIRED_PROVIDERS = frozenset({"openai", "azure"})
 
+# Providers whose chat completions API rejects `file` content blocks outright.
+# Azure OpenAI answers `BadRequestError - Invalid Value: 'file'. This model does
+# not support file content types.` for a `file` block whether it carries
+# `file_data` or a `file_id` from an uploaded file, so there is no shape of file
+# block to send and the request has to describe the file in text instead.
+_FILE_CONTENT_UNSUPPORTED_PROVIDERS = frozenset({"azure"})
+
 # Routing-only prefix: requests go through a LiteLLM Proxy deployment, but the
 # payload must still be shaped for the provider named in the next segment.
 _PROXY_PROVIDER = "litellm_proxy"
@@ -485,6 +492,25 @@ def _redact_file_uri_for_log(
   if tail:
     return f"{parsed.scheme}://<redacted>/{tail}"
   return f"{parsed.scheme}://<redacted>"
+
+
+def _supports_file_content_blocks(provider: str, model: str) -> bool:
+  """Returns True when the provider accepts `file` content blocks at all."""
+  # A proxied request is shaped for the provider named after the prefix, but the
+  # proxy sits in front of it and may rewrite file blocks into whatever that
+  # deployment takes. Left to the provider's own answer, a proxy that already
+  # handles files would lose that ability here.
+  if model.lower().startswith(_PROXY_PROVIDER + "/"):
+    return True
+  return provider not in _FILE_CONTENT_UNSUPPORTED_PROVIDERS
+
+
+def _file_reference_text(identifier: str) -> str:
+  """Returns the text that stands in for a file the provider cannot accept."""
+  # Names the file rather than dropping it: the model still sees that a file was
+  # attached and what it was called, so it can say what it cannot read instead
+  # of answering as if nothing had been sent.
+  return f'[File reference: "{identifier}"]'
 
 
 def _is_file_uri_supported(provider: str, model: str, file_uri: str) -> bool:
@@ -1573,6 +1599,28 @@ async def _get_content(
         content_objects.append(
             _VideoContentObject(type="video_url", video_url={"url": data_uri})
         )
+      elif not _supports_file_content_blocks(provider, model):
+        # Checked before the upload below: uploading first would spend a request
+        # and leave a file behind that no message can then refer to.
+        logger.debug(
+            "Inline file %s cannot be sent as a file content block to provider"
+            " %s, using text fallback.",
+            _redact_file_uri_for_log(
+                "inline_data", display_name=part.inline_data.display_name
+            ),
+            provider,
+        )
+        content_objects.append(
+            _TextContentObject(
+                type="text",
+                # Falls back to the MIME type because inline data often arrives
+                # without a display name, and `[File reference: "None"]` tells
+                # the model less than the kind of file that was attached.
+                text=_file_reference_text(
+                    part.inline_data.display_name or mime_type
+                ),
+            )
+        )
       elif mime_type in _SUPPORTED_FILE_CONTENT_MIME_TYPES:
         # OpenAI/Azure require file_id from uploaded file, not inline data
         if provider in _FILE_ID_REQUIRED_PROVIDERS:
@@ -1610,6 +1658,7 @@ async def _get_content(
     elif part.file_data and part.file_data.file_uri:
       if (
           provider in _FILE_ID_REQUIRED_PROVIDERS
+          and _supports_file_content_blocks(provider, model)
           and _looks_like_openai_file_id(part.file_data.file_uri)
       ):
         content_objects.append(
@@ -1656,6 +1705,30 @@ async def _get_content(
                 )
             )
             continue
+
+      # Placed after the media-URL shortcuts above: those emit `image_url` and
+      # `video_url` blocks, which the provider does accept, and only a `file`
+      # block has to be replaced.
+      if not _supports_file_content_blocks(provider, model):
+        identifier = part.file_data.display_name or _redact_file_uri_for_log(
+            part.file_data.file_uri
+        )
+        logger.debug(
+            "File URI %s cannot be sent as a file content block to provider %s,"
+            " using text fallback.",
+            identifier,
+            provider,
+        )
+        content_objects.append(
+            _TextContentObject(
+                type="text",
+                # A URI is redacted rather than quoted verbatim, because it can
+                # carry a signed token, and this string is sent to the model and
+                # kept in session history.
+                text=_file_reference_text(identifier),
+            )
+        )
+        continue
 
       if not _is_file_uri_supported(provider, model, part.file_data.file_uri):
         redacted_file_uri = _redact_file_uri_for_log(

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -5525,6 +5525,43 @@ async def test_get_content_pdf_non_openai_uses_file_data():
 
 
 @pytest.mark.asyncio
+async def test_get_content_unsupported_inline_mime_type_falls_back_to_text():
+  """A MIME type no provider takes as a file is named, not raised over.
+
+  The attachment is one part of a request whose remaining parts are answerable,
+  so the turn continues and the model is told what it was not given.
+  """
+  parts = [
+      types.Part.from_text(text="What is in here?"),
+      types.Part.from_bytes(data=b"PK\x03\x04", mime_type="application/zip"),
+  ]
+
+  content = await _get_content(parts, provider="anthropic")
+
+  assert content == [
+      {"type": "text", "text": "What is in here?"},
+      {"type": "text", "text": '[File reference: "application/zip"]'},
+  ]
+
+
+@pytest.mark.asyncio
+async def test_get_content_unsupported_inline_mime_type_uses_display_name():
+  parts = [
+      types.Part(
+          inline_data=types.Blob(
+              data=b"PK\x03\x04",
+              mime_type="application/zip",
+              display_name="logs.zip",
+          )
+      )
+  ]
+
+  content = await _get_content(parts, provider="anthropic")
+
+  assert content == [{"type": "text", "text": '[File reference: "logs.zip"]'}]
+
+
+@pytest.mark.asyncio
 async def test_get_content_guess_extension_fallback(mocker):
   """Test that guess_extension fallback is used when guess_extension returns None."""
   import mimetypes

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -3468,7 +3468,6 @@ async def test_get_content_file_uri(file_uri, mime_type):
     "provider,model",
     [
         ("openai", "openai/gpt-4o"),
-        ("azure", "azure/gpt-4"),
     ],
 )
 async def test_get_content_file_uri_file_id_required_raises_error(
@@ -3571,7 +3570,6 @@ async def test_get_content_file_uri_media_url_file_id_required_uses_url_type(
     "provider,model",
     [
         ("openai", "openai/gpt-4o"),
-        ("azure", "azure/gpt-4"),
     ],
 )
 async def test_get_content_file_uri_file_id_required_preserves_file_id(
@@ -3590,25 +3588,10 @@ async def test_get_content_file_uri_file_id_required_preserves_file_id(
 
 
 @pytest.mark.asyncio
-async def test_get_content_file_uri_azure_preserves_assistant_file_id():
-  parts = [
-      types.Part(
-          file_data=types.FileData(
-              file_uri="assistant-abc123",
-              mime_type="application/pdf",
-          )
-      )
-  ]
-  content = await _get_content(parts, provider="azure", model="azure/gpt-4.1")
-  assert content == [{"type": "file", "file": {"file_id": "assistant-abc123"}}]
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "provider,model",
     [
         ("openai", "openai/gpt-4o"),
-        ("azure", "azure/gpt-4"),
     ],
 )
 async def test_get_content_file_uri_http_pdf_file_id_required_raises_error(
@@ -3869,11 +3852,10 @@ async def test_get_content_audio_inline_data_emits_input_audio(
     "provider,model",
     [
         ("openai", "openai/gpt-4o"),
-        ("azure", "azure/gpt-4"),
     ],
 )
 async def test_get_content_audio_file_uri_http_raises_error(provider, model):
-  """Audio HTTP file_uri raises an error for openai/azure."""
+  """Audio HTTP file_uri raises an error for openai."""
   file_uri = "https://example.com/audio.mp3"
   parts = [
       types.Part(
@@ -5538,28 +5520,8 @@ async def test_get_content_pdf_non_openai_uses_file_data():
   assert "file_id" not in content[0]["file"]
 
 
-@pytest.mark.asyncio
-async def test_get_content_pdf_azure_uses_file_id(mocker):
-  """Test that PDF files use file_id for Azure provider."""
-  mock_file_response = mocker.create_autospec(litellm.FileObject)
-  mock_file_response.id = "file-xyz789"
-  mock_acreate_file = AsyncMock(return_value=mock_file_response)
-  mocker.patch.object(litellm, "acreate_file", new=mock_acreate_file)
-
-  parts = [
-      types.Part.from_bytes(data=b"test_pdf_data", mime_type="application/pdf")
-  ]
-  content = await _get_content(parts, provider="azure")
-
-  assert content[0]["type"] == "file"
-  assert content[0]["file"]["file_id"] == "file-xyz789"
-  assert content[0]["file"]["format"] == "application/pdf"
-
-  mock_acreate_file.assert_called_once_with(
-      file=("document.pdf", b"test_pdf_data", "application/pdf"),
-      purpose="assistants",
-      custom_llm_provider="azure",
-  )
+# Azure rejects `file` content blocks outright, so it no longer uploads or sends
+# one. See test_litellm_azure_file_fallback.py for what it sends instead.
 
 
 @pytest.mark.asyncio

--- a/tests/unittests/models/test_litellm_azure_file_fallback.py
+++ b/tests/unittests/models/test_litellm_azure_file_fallback.py
@@ -1,0 +1,313 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for attachments sent to Azure, which rejects `file` content blocks.
+
+Azure OpenAI answers ``BadRequestError - Invalid Value: 'file'. This model does
+not support file content types.`` to any ``file`` block, whether it carries
+inline ``file_data`` or a ``file_id`` from an uploaded file. Every attachment
+that would become such a block is sent as a text reference instead, so the
+request goes through and the model still learns what was attached.
+"""
+
+from unittest.mock import AsyncMock
+
+from google.adk.models.lite_llm import _get_completion_inputs
+from google.adk.models.lite_llm import _get_content
+from google.adk.models.lite_llm import _get_provider_from_model
+from google.adk.models.llm_request import LlmRequest
+from google.genai import types
+import litellm
+import pytest
+
+_AZURE_MODEL = "azure/gpt-4.1"
+
+
+def _no_upload(mocker) -> AsyncMock:
+  """Patches the file upload so a stray call is visible rather than attempted."""
+  mock_acreate_file = AsyncMock()
+  mocker.patch.object(litellm, "acreate_file", new=mock_acreate_file)
+  return mock_acreate_file
+
+
+@pytest.mark.asyncio
+async def test_azure_inline_file_is_sent_as_a_text_reference(mocker):
+  mock_acreate_file = _no_upload(mocker)
+  parts = [
+      types.Part.from_bytes(data=b"test_pdf_data", mime_type="application/pdf")
+  ]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [
+      {"type": "text", "text": '[File reference: "application/pdf"]'}
+  ]
+  # Not uploaded either: the upload costs a request and leaves a file behind
+  # that no message can then refer to.
+  mock_acreate_file.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_azure_inline_file_reference_names_the_file_when_it_can(mocker):
+  _no_upload(mocker)
+  parts = [
+      types.Part(
+          inline_data=types.Blob(
+              data=b"test_pdf_data",
+              mime_type="application/pdf",
+              display_name="quarterly_report.pdf",
+          )
+      )
+  ]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [
+      {"type": "text", "text": '[File reference: "quarterly_report.pdf"]'}
+  ]
+
+
+@pytest.mark.asyncio
+async def test_azure_inline_unsupported_mime_type_is_sent_as_a_text_reference(
+    mocker,
+):
+  """A type Azure could never take is a text reference, not a ValueError.
+
+  Other providers still raise for these, but Azure cannot accept any file block,
+  so there is nothing to raise about: the request is already degraded to text.
+  """
+  _no_upload(mocker)
+  parts = [
+      types.Part.from_bytes(data=b"PK\x03\x04", mime_type="application/zip")
+  ]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [
+      {"type": "text", "text": '[File reference: "application/zip"]'}
+  ]
+
+
+@pytest.mark.asyncio
+async def test_azure_file_uri_is_sent_as_a_text_reference():
+  parts = [
+      types.Part(
+          file_data=types.FileData(
+              file_uri="gs://bucket/path/to/document.pdf",
+              mime_type="application/pdf",
+              display_name="document.pdf",
+          )
+      )
+  ]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [
+      {"type": "text", "text": '[File reference: "document.pdf"]'}
+  ]
+
+
+@pytest.mark.asyncio
+async def test_azure_file_uri_without_a_display_name_is_redacted():
+  """The reference is sent to the model, so a URI cannot be quoted verbatim."""
+  parts = [
+      types.Part(
+          file_data=types.FileData(
+              file_uri="https://storage.example.com/document.pdf?sig=secret",
+              mime_type="application/pdf",
+          )
+      )
+  ]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [{
+      "type": "text",
+      "text": '[File reference: "https://<redacted>/document.pdf"]',
+  }]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "file_uri,expected_identifier",
+    [
+        ("file-abc123", "file-<redacted>"),
+        ("assistant-abc123", "assistant-<redacted>"),
+    ],
+)
+async def test_azure_uploaded_file_id_is_sent_as_a_text_reference(
+    file_uri, expected_identifier
+):
+  """An already-uploaded file id is no more acceptable to Azure than bytes."""
+  parts = [
+      types.Part(
+          file_data=types.FileData(
+              file_uri=file_uri, mime_type="application/pdf"
+          )
+      )
+  ]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [
+      {"type": "text", "text": f'[File reference: "{expected_identifier}"]'}
+  ]
+
+
+@pytest.mark.asyncio
+async def test_azure_request_carries_no_file_content_block(mocker):
+  """The end-to-end guard for the reported BadRequestError.
+
+  Asserts on the assembled message rather than on `_get_content`, because the
+  400 was raised for the request as a whole.
+  """
+  mock_acreate_file = _no_upload(mocker)
+  llm_request = LlmRequest(
+      model=_AZURE_MODEL,
+      contents=[
+          types.Content(
+              role="user",
+              parts=[
+                  types.Part.from_text(text="Summarize this"),
+                  types.Part(
+                      inline_data=types.Blob(
+                          data=b"test_pdf_data",
+                          mime_type="application/pdf",
+                          display_name="report.pdf",
+                      )
+                  ),
+              ],
+          )
+      ],
+      config=types.GenerateContentConfig(tools=[]),
+  )
+
+  messages, _, _, _, _ = await _get_completion_inputs(
+      llm_request, model=_AZURE_MODEL
+  )
+
+  assert messages[0]["content"] == [
+      {"type": "text", "text": "Summarize this"},
+      {"type": "text", "text": '[File reference: "report.pdf"]'},
+  ]
+  mock_acreate_file.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_azure_still_sends_inline_images_as_image_url():
+  """Only `file` blocks are replaced; Azure does accept `image_url`."""
+  parts = [types.Part.from_bytes(data=b"png_bytes", mime_type="image/png")]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [{
+      "type": "image_url",
+      "image_url": {"url": "data:image/png;base64,cG5nX2J5dGVz"},
+  }]
+
+
+@pytest.mark.asyncio
+async def test_azure_still_sends_inline_audio_as_input_audio():
+  parts = [types.Part.from_bytes(data=b"mp3_bytes", mime_type="audio/mpeg")]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [{
+      "type": "input_audio",
+      "input_audio": {"data": "bXAzX2J5dGVz", "format": "mp3"},
+  }]
+
+
+@pytest.mark.asyncio
+async def test_azure_still_sends_an_http_image_uri_as_image_url():
+  """The media-URL shortcut has to keep running before the text fallback."""
+  file_uri = "https://example.com/photo.png"
+  parts = [
+      types.Part(
+          file_data=types.FileData(file_uri=file_uri, mime_type="image/png")
+      )
+  ]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [{"type": "image_url", "image_url": {"url": file_uri}}]
+
+
+@pytest.mark.asyncio
+async def test_azure_still_reads_inline_text_files_as_text():
+  """A text file was never a `file` block, so its contents still go through."""
+  parts = [
+      types.Part.from_text(text="Here it is"),
+      types.Part.from_bytes(data=b"line one", mime_type="text/plain"),
+  ]
+
+  content = await _get_content(parts, provider="azure", model=_AZURE_MODEL)
+
+  assert content == [
+      {"type": "text", "text": "Here it is"},
+      {"type": "text", "text": "line one"},
+  ]
+
+
+@pytest.mark.asyncio
+async def test_proxied_azure_still_uploads_and_sends_a_file_id(mocker):
+  """A LiteLLM Proxy in front of Azure may translate files itself.
+
+  The payload is shaped for the provider named after the prefix, but the proxy
+  is what receives it, so the provider's own answer is not the last word and
+  upstream's upload path is left in place.
+  """
+  mock_file_response = mocker.create_autospec(litellm.FileObject)
+  mock_file_response.id = "file-abc123"
+  mock_acreate_file = AsyncMock(return_value=mock_file_response)
+  mocker.patch.object(litellm, "acreate_file", new=mock_acreate_file)
+
+  model = "litellm_proxy/azure/my-deployment"
+  parts = [
+      types.Part.from_bytes(data=b"test_pdf_data", mime_type="application/pdf")
+  ]
+
+  content = await _get_content(
+      parts, provider=_get_provider_from_model(model), model=model
+  )
+
+  assert content == [{
+      "type": "file",
+      "file": {"file_id": "file-abc123", "format": "application/pdf"},
+  }]
+  mock_acreate_file.assert_called_once_with(
+      file=("document.pdf", b"test_pdf_data", "application/pdf"),
+      purpose="assistants",
+      custom_llm_provider="openai",
+  )
+
+
+@pytest.mark.asyncio
+async def test_openai_still_uploads_and_sends_a_file_id(mocker):
+  """The fallback is Azure-only: OpenAI does accept `file` blocks."""
+  mock_file_response = mocker.create_autospec(litellm.FileObject)
+  mock_file_response.id = "file-abc123"
+  mock_acreate_file = AsyncMock(return_value=mock_file_response)
+  mocker.patch.object(litellm, "acreate_file", new=mock_acreate_file)
+
+  parts = [
+      types.Part.from_bytes(data=b"test_pdf_data", mime_type="application/pdf")
+  ]
+
+  content = await _get_content(parts, provider="openai", model="openai/gpt-4o")
+
+  assert content == [{
+      "type": "file",
+      "file": {"file_id": "file-abc123", "format": "application/pdf"},
+  }]


### PR DESCRIPTION
Port of #18 (`usFeat/azure attached file fallback`) onto ADK 2.7.1.

Base is `custom-ver2.7.1`, a pure copy of upstream `e753651b`, so the diff below is exactly the fork's divergence.

## The problem

Azure OpenAI answers any `file` content block in a chat completion with:

```
litellm.exceptions.BadRequestError: litellm.BadRequestError: AzureException
BadRequestError - Invalid Value: 'file'. This model does not support file content types.
```

This is raised by `acompletion`, not by `acreate_file` — the upload succeeds and the completion is then rejected. It happens whether the block carries inline `file_data` or a `file_id` from an uploaded file, so there is no shape of `file` block to send and every attachment to an Azure model fails the whole turn.

### 2.7.1 does not fix this

Upstream `ff4567df fix: pass file metadata tuple to Azure for PDF uploads` touches only the upload call:

```diff
-              file=part.inline_data.data,
+              file=(filename, part.inline_data.data, mime_type),
```

The chat block it then sends is unchanged — still `{"type": "file", "file": {"file_id": ..., "format": ...}}`. Upstream has in fact moved the other way since #18, replacing fallbacks with hard errors (`8847f238 feat: raise explicit error for unsupported LiteLlm file attachments`, `42eceb3a fix: raise ValueError for unsupported MIME types in file_data URI path`), so azure + a `gs://` `file_uri` now raises `ValueError` where the fork used to degrade to text.

## The change

Two commits, in decreasing order of confidence. The second is droppable on its own.

### 1. `fix(litellm): send Azure a text reference instead of a file content block`

New `_FILE_CONTENT_UNSUPPORTED_PROVIDERS = frozenset({"azure"})` and `_supports_file_content_blocks(provider, model)`. Anything that would become a `file` block is sent as `[File reference: "<name>"]` text instead, on both the `inline_data` and the `file_data` path.

| case | 2.7.1 | this branch |
| --- | --- | --- |
| inline PDF/docx/pptx/json/sh | upload → `file` block → **400** | `[File reference: "report.pdf"]` |
| `file_data` = `gs://…`, `https://…pdf` | `ValueError` | `[File reference: "document.pdf"]` |
| `file_data` = `file-abc123` / `assistant-abc123` | `file` block → **400** | `[File reference: "file-<redacted>"]` |
| inline unsupported MIME (e.g. zip) | `ValueError` | `[File reference: "application/zip"]` |
| inline image / audio | `image_url` / `input_audio` | unchanged |
| `file_data` HTTP image / video | `image_url` / `video_url` | unchanged |
| inline `text/*` | decoded as text | unchanged |
| `litellm_proxy/azure/…` | upload → `file_id` | unchanged |

Notes on the judgement calls:

- **Scoped to `file` blocks.** Azure does accept `image_url`, `video_url` and `input_audio`, so the fallback sits *after* the media-URL shortcuts rather than at the top of the branch. Images and audio to Azure are unaffected.
- **No upload for Azure.** The check runs before `litellm.acreate_file`, because uploading first would spend a request and leave a file behind that no message can then refer to.
- **`litellm_proxy/azure/…` keeps the upload path.** The payload is shaped for the provider named after the prefix, but the proxy is what receives it and may translate file blocks into whatever the deployment takes — the same reasoning `_is_file_uri_supported` already applies to proxied models. This also matches #18's effective behavior: at the time, `_get_provider_from_model("litellm_proxy/azure/…")` returned `litellm_proxy`, so the fork's check never fired for proxied models either. Upstream `602e58db` changed that resolution, hence the explicit exemption here.
- **A URI without a display name is redacted** to `scheme://<redacted>/<tail>` before it goes into the reference. Unlike the log helper's usual callers, this string is sent to the model and stored in session history, and a signed URL carries its token in the query.
- **Identifier falls back to the MIME type** for inline data, which often has no `display_name`; `[File reference: "None"]` tells the model less than `[File reference: "application/pdf"]`.

Six upstream tests asserted the old Azure behavior. Four were parametrized over openai and azure and keep their openai case; the two Azure-specific ones (`test_get_content_pdf_azure_uses_file_id`, `test_get_content_file_uri_azure_preserves_assistant_file_id`) are replaced by the new test file, with a pointer left at the deletion site.

### 2. `fix(litellm): name an unsendable inline file instead of raising`

The second half of #18: an inline part whose MIME type is outside `_SUPPORTED_FILE_CONTENT_MIME_TYPES` no longer raises `LiteLlm(BaseLlm) does not support content part with MIME type ...` but gets the same text reference.

Separated because **it changes behavior for every provider, not just Azure** — after commit 1, Azure never reaches this branch, so commit 1 is a complete Azure fix on its own. It restores the fork's pre-2.7.1 behavior and reverts an upstream decision (`8847f238`). Drop this commit if you would rather keep the loud failure for non-Azure providers.

No test covered the raise, so nothing asserted the old behavior.

## Deliberately not changed

- `_FILE_ID_REQUIRED_PROVIDERS` still contains `azure`, unlike #18 which removed it. The set describes *which shape* a provider needs if it takes files at all, and it still gates the HTTP media-URL handling that Azure does use. Whether Azure takes files at all is now a separate question, answered by `_supports_file_content_blocks`.
- `_is_file_uri_supported`'s `ValueError` for anthropic and non-Gemini Vertex AI. #18 predates that raise; it is upstream's own later decision (`42eceb3a`) and outside this port.

## One thing to confirm

The fallback is unconditional for Azure, as in #18. Azure OpenAI's support for `type: "file"` in chat completions depends on the deployment's model and `api-version`, so a deployment that has since gained support would now get `[File reference: "report.pdf"]` instead of the document itself. If that becomes a concern, the natural follow-up is a `LiteLlm` field or env var that turns `_FILE_CONTENT_UNSUPPORTED_PROVIDERS` off without a code change.

## Testing

- New `tests/unittests/models/test_litellm_azure_file_fallback.py`: 14 tests covering each row of the table above, including an end-to-end `_get_completion_inputs` assertion that the assembled Azure message carries no `file` block at all — the direct guard for the reported 400.
- 2 tests added to `test_litellm.py` for commit 2.
- `tests/unittests/models`: **1110 passed**.
- `tests/unittests` (excluding the 3 failures that also fail on `custom-ver2.7.1`: `artifacts/test_artifact_service.py::test_metadata_and_payload_share_permissions` and `test_import_loading.py::test_entry_point_loads_only_allowlisted_packages[agent|runner]`): **11938 passed, 89 skipped, 33 xfailed, 1 xpassed**.
- `isort` 8.0.1 and `pyink` 25.12.0 clean.
- Not verified: a real request against a live Azure deployment.
